### PR TITLE
Updating Metrics service default port to 9546

### DIFF
--- a/docs/HowTo/Monitor-Nodes/Metrics.md
+++ b/docs/HowTo/Monitor-Nodes/Metrics.md
@@ -38,7 +38,7 @@ To configure Prometheus to run with EthSigner:
             metrics_path: /metrics
             scheme: http
             static_configs:
-            - targets: ["localhost:8546"]
+            - targets: ["localhost:9546"]
         ```
 
     !!! note
@@ -62,7 +62,7 @@ To configure Prometheus to run with EthSigner:
 
         To view the full list of available EthSigner metrics view
         `http://<metrics-host>:<metrics-port>/metrics`. By default this is
-        `http://localhost:8546/metrics`.
+        `http://localhost:9546/metrics`.
 
 1. In another terminal, run Prometheus specifying the `prometheus.yml` file:
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -616,7 +616,7 @@ accepts access from `localhost` and `127.0.0.1`.
 ### `metrics-port`
 
 The port (TCP) on which [Prometheus](https://prometheus.io/) accesses
-EthSigner metrics. The default is `8546`.
+EthSigner metrics. The default is `9546`.
 
 === "Syntax"
 


### PR DESCRIPTION
## Description

Updating Metrics service default port to 9546

<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
https://github.com/ConsenSys/ethsigner/issues/366

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation


